### PR TITLE
 + now able to specify the config file at runtime

### DIFF
--- a/NesiConsultancy/AtomsCavityBasisDemo.py
+++ b/NesiConsultancy/AtomsCavityBasisDemo.py
@@ -26,7 +26,7 @@ configs = configparser.ConfigParser()
 conffile = args.conffile
 try:
     with open(conffile) as f:
-        configs.read_file(conffile)
+        configs.read(conffile)
 except IOError:
     raise RuntimeError(f'Config file {conffile} does not exist!')
 

--- a/NesiConsultancy/AtomsCavityBasisDemo.py
+++ b/NesiConsultancy/AtomsCavityBasisDemo.py
@@ -25,10 +25,10 @@ args = parser.parse_args()
 configs = configparser.ConfigParser()
 conffile = args.conffile
 try:
-    with open() as f:
+    with open(conffile) as f:
         configs.read_file(conffile)
 except IOError:
-    raise RuntimeError(f'Config file {confifile} does not exist!')
+    raise RuntimeError(f'Config file {conffile} does not exist!')
 
 # Assign parameters
 eps = configs['PARAMS'].getfloat('eps')

--- a/NesiConsultancy/AtomsCavityBasisDemo.py
+++ b/NesiConsultancy/AtomsCavityBasisDemo.py
@@ -11,10 +11,24 @@ import numpy as np
 import matplotlib.pyplot as plt
 import time
 import configparser
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(
+                    prog=sys.argv[0],
+                    description='NeSI test case')
+parser.add_argument('-c', '--conffile', default='config.ini',
+                    help='Path to the configuration file')
+args = parser.parse_args()
 
 #%% Read in configs
 configs = configparser.ConfigParser()
-configs.read('config.ini')
+conffile = args.conffile
+try:
+    with open() as f:
+        configs.read_file(conffile)
+except IOError:
+    raise RuntimeError(f'Config file {confifile} does not exist!')
 
 # Assign parameters
 eps = configs['PARAMS'].getfloat('eps')

--- a/NesiConsultancy/AtomsCavityBasisDemoProfile.sl
+++ b/NesiConsultancy/AtomsCavityBasisDemoProfile.sl
@@ -6,6 +6,6 @@
 
 module purge
 module load Python
-python -m cProfile -o output.pstats AtomsCavityBasisDemo.py
+python -m cProfile -o output.pstats AtomsCavityBasisDemo.py -c config.ini
 gprof2dot --colour-nodes-by-selftime -f pstats output.pstats | \
     dot -Tpng -o output.png


### PR DESCRIPTION
Hi @aell060 ,

With this change the user can specify the config file at run time

$ python NesiConsultancy/AtomsCavityBasisDemo.py -h
usage: NesiConsultancy/AtomsCavityBasisDemo.py [-h] [-c CONFFILE]

NeSI test case

options:
  -h, --help            show this help message and exit
  -c CONFFILE, --conffile CONFFILE
                        Path to the configuration file

We're also checking that the file exists

$ python NesiConsultancy/AtomsCavityBasisDemo.py -c toto.txt
Traceback (most recent call last):
  File "/scale_wlg_nobackup/filesets/nobackup/pletzera/NonClassicalLightNesi/NesiConsultancy/AtomsCavityBasisDemo.py", line 28, in <module>
    with open(conffile) as f:
         ^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'toto.txt'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/scale_wlg_nobackup/filesets/nobackup/pletzera/NonClassicalLightNesi/NesiConsultancy/AtomsCavityBasisDemo.py", line 31, in <module>
    raise RuntimeError(f'Config file {conffile} does not exist!')
RuntimeError: Config file toto.txt does not exist!