### PR TITLE
 + support for map profiling

### DIFF
--- a/NesiConsultancy/AtomsCavityBasisDemoProfile_large2.sl
+++ b/NesiConsultancy/AtomsCavityBasisDemoProfile_large2.sl
@@ -1,14 +1,26 @@
 #!/bin/bash -e
 #SBATCH --job-name=AtomsCavityBasisDemo # job name (shows up in the queue)
-#SBATCH --time=24:00:00      # Walltime (HH:MM:SS)
+#SBATCH --time=02:00:00      # Walltime (HH:MM:SS)
 #SBATCH --mem=50GB          # Memory in MB
+#SBATCH --cpus-per-task=4   # number of threads
 
-
-#SBATCH --mail-type=ALL
-#SBATCH --mail-user=mleo705@aucklanduni.ac.nz
+while getopts p: flag
+do
+    case "${flag}" in
+       p) profiler=${OPTARG};;
+    esac
+done
 
 module purge
 module load Python
-python -m cProfile -o output.pstats AtomsCavityBasisDemo.py -c ./Configs/largeconfig2.ini
-gprof2dot --colour-nodes-by-selftime -f pstats output.pstats | \
+
+if [ "$profiler" == "map" ]; then
+    echo "Using FORGE MAP..."
+    module load forge
+    srun map --profile python AtomsCavityBasisDemo.py -c ./Configs/largeconfig2.ini
+else
+    echo "Using GPROF..."
+    python -m cProfile -o output.pstats AtomsCavityBasisDemo.py -c ./Configs/largeconfig2.ini
+    gprof2dot --colour-nodes-by-selftime -f pstats output.pstats | \
     dot -Tpng -o output_large2.png
+fi


### PR DESCRIPTION
You can now specify whether you want to use the forge map or gprof as profiler. By default the gprof profiler will be used. If you want to run the forge map profiler type

sbatch AtomsCavityBasisDemoProfile_large2.sl -p map

This will generate a map file. You can open the map file with

ml forge
map <file.map>




